### PR TITLE
Yatomata OSGified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,41 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>jar</supportedProjectType>
+                    </supportedProjectTypes>
+                    <instructions>
+                        <Export-Package>
+                            ru.yandex.qatools.fsm,
+                            ru.yandex.qatools.fsm.annotations,
+                            ru.yandex.qatools.fsm.impl
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>

--- a/src/main/java/ru/yandex/qatools/fsm/impl/BestMatchedAnnotatedMethodCaller.java
+++ b/src/main/java/ru/yandex/qatools/fsm/impl/BestMatchedAnnotatedMethodCaller.java
@@ -10,7 +10,7 @@ import java.util.*;
 /**
  * @author Ilya Sadykov (mailto: smecsia@yandex-team.ru)
  */
-public class BestMatchedAnnotatedMethodCaller {
+class BestMatchedAnnotatedMethodCaller {
 
     private final Object instance;
     private final Metadata.ClassInfo cache;

--- a/src/main/java/ru/yandex/qatools/fsm/impl/YatomataImpl.java
+++ b/src/main/java/ru/yandex/qatools/fsm/impl/YatomataImpl.java
@@ -15,7 +15,7 @@ import static ru.yandex.qatools.fsm.impl.Metadata.get;
 /**
  * @author Ilya Sadykov
  */
-public class YatomataImpl<T> implements Yatomata<T> {
+class YatomataImpl<T> implements Yatomata<T> {
     private final Class<T> fsmClass;
     private Object currentState;
     private boolean completed = false;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/BeforeAndAfterTransitTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/BeforeAndAfterTransitTest.java
@@ -1,4 +1,4 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +13,8 @@ import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 
 /**
  * @author Ilya Sadykov

--- a/src/test/java/ru/yandex/qatools/fsm/impl/CompletedCounterStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/CompletedCounterStateMachineTest.java
@@ -1,6 +1,8 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.OnTransit;
 import ru.yandex.qatools.fsm.annotations.Transit;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/EventStateStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/EventStateStateMachineTest.java
@@ -1,7 +1,9 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.*;
 import ru.yandex.qatools.fsm.beans.UndefinedEvent;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/ExecuteStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/ExecuteStateMachineTest.java
@@ -1,7 +1,10 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.StateMachineException;
+import ru.yandex.qatools.fsm.StopConditionAware;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.*;
 import ru.yandex.qatools.fsm.impl.YatomataImpl;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/FallenRaisedStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/FallenRaisedStateMachineTest.java
@@ -1,7 +1,10 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.StopConditionAware;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.OnTransit;
 import ru.yandex.qatools.fsm.annotations.Transit;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/IncorrectStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/IncorrectStateMachineTest.java
@@ -1,7 +1,9 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.StateMachineException;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.*;
 import ru.yandex.qatools.fsm.impl.YatomataImpl;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/LifecycleStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/LifecycleStateMachineTest.java
@@ -1,7 +1,9 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.OnTransit;
 import ru.yandex.qatools.fsm.annotations.Transit;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/OnExceptionStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/OnExceptionStateMachineTest.java
@@ -1,7 +1,8 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.*;
 import ru.yandex.qatools.fsm.impl.YatomataImpl;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/ParentAnnotationsStateMachineTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/ParentAnnotationsStateMachineTest.java
@@ -1,6 +1,8 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.OnTransit;
 import ru.yandex.qatools.fsm.annotations.Transit;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/TestsCountByDayAggregatorTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/TestsCountByDayAggregatorTest.java
@@ -1,7 +1,9 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.FSM;
 import ru.yandex.qatools.fsm.annotations.OnTransit;
 import ru.yandex.qatools.fsm.annotations.Transit;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/TransitWithSameStateAndEventClassTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/TransitWithSameStateAndEventClassTest.java
@@ -1,7 +1,9 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.TestEvent;
 import ru.yandex.qatools.fsm.beans.TestStarted;

--- a/src/test/java/ru/yandex/qatools/fsm/impl/TransitWithStateOnlyTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/TransitWithStateOnlyTest.java
@@ -1,8 +1,10 @@
-package ru.yandex.qatools.fsm;
+package ru.yandex.qatools.fsm.impl;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import ru.yandex.qatools.fsm.FSMException;
+import ru.yandex.qatools.fsm.Yatomata;
 import ru.yandex.qatools.fsm.annotations.*;
 import ru.yandex.qatools.fsm.beans.*;
 import ru.yandex.qatools.fsm.impl.YatomataImpl;


### PR DESCRIPTION
Made Yatomata usable in OSGi environment by generating necessary Manifest headers. Additionally made several classes, which (I believe) not belong to public API, hidden.