### PR TITLE
Fixed stupid NPE in FSMBuilder with instance logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Just add the following dependency to your pom.xml:
     <dependency>
         <groupId>ru.yandex.qatools</groupId>
         <artifactId>yatomata</artifactId>
-        <version>1.10</version>
+        <version>1.11</version>
     </dependency>
 ```
 

--- a/src/main/java/ru/yandex/qatools/fsm/impl/FSMBuilder.java
+++ b/src/main/java/ru/yandex/qatools/fsm/impl/FSMBuilder.java
@@ -42,11 +42,16 @@ public class FSMBuilder<T> implements Yatomata.Builder<T> {
         try {
             T inst = (instance != null) ? instance : fsmClass.newInstance(); 
             if (state == null) {
-                return new YatomataImpl<>(fsmClass, inst);
+                return new YatomataImpl<>(getFsmClass(), inst);
             }
-            return new YatomataImpl<>(fsmClass, inst, state);
+            return new YatomataImpl<>(getFsmClass(), inst, state);
         } catch (Exception e) {
-            throw new RuntimeException("Could not initialize the FSM Engine for FSM " + fsmClass, e);
+            throw new RuntimeException("Could not initialize the FSM Engine for FSM " + getFsmClass(), e);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<T> getFsmClass() {
+        return (instance != null) ? (Class<T>) instance.getClass() : fsmClass;
     }
 }

--- a/src/test/java/ru/yandex/qatools/fsm/impl/FSMBuilderTest.java
+++ b/src/test/java/ru/yandex/qatools/fsm/impl/FSMBuilderTest.java
@@ -1,0 +1,55 @@
+package ru.yandex.qatools.fsm.impl;
+
+import org.junit.Test;
+import ru.yandex.qatools.fsm.annotations.FSM;
+import ru.yandex.qatools.fsm.annotations.OnTransit;
+import ru.yandex.qatools.fsm.annotations.Transit;
+import ru.yandex.qatools.fsm.annotations.Transitions;
+import ru.yandex.qatools.fsm.beans.TestEvent;
+import ru.yandex.qatools.fsm.beans.TestStarted;
+import ru.yandex.qatools.fsm.beans.TestStartedState;
+import ru.yandex.qatools.fsm.beans.UndefinedState;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class FSMBuilderTest {
+
+    @FSM(start = UndefinedState.class)
+    @Transitions({
+            @Transit(from = UndefinedState.class, to = TestStartedState.class, on = TestEvent.class)
+    })
+    public static class FsmWithConstructor {
+        
+        private final AtomicInteger counter;
+        
+        FsmWithConstructor(int initialValue) {
+            this.counter = new AtomicInteger(initialValue);
+        }
+
+        @OnTransit
+        public void onTestStart(TestEvent event) {
+            counter.getAndIncrement();
+        }
+
+        int getCounter() {
+            return counter.get();
+        }
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void testFailedToInstantiateFsm() {
+        new FSMBuilder<>(FsmWithConstructor.class).build();
+    }
+    
+    @Test
+    public void testFsmFromInstance() {
+        FsmWithConstructor instance = new FsmWithConstructor(0);
+        FSMBuilder<FsmWithConstructor> fsm = new FSMBuilder<>(instance);
+        fsm.build().fire(new TestStarted());
+        assertThat(instance.getCounter(), equalTo(1));
+    }
+    
+}


### PR DESCRIPTION
In current implementation even if we pass FSM instance class field with null value is passed to Metadata causing an NPE. Covered this stuff by test.